### PR TITLE
fixed typo in the image name of lvm-driver

### DIFF
--- a/lvm-operator.yaml
+++ b/lvm-operator.yaml
@@ -1473,7 +1473,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: openebs-lvm-plugin
-          image: openebs/lvm-driver1.2.0
+          image: openebs/lvm-driver:1.2.0
           imagePullPolicy: IfNotPresent
           env:
             - name: OPENEBS_CONTROLLER_DRIVER
@@ -1669,7 +1669,7 @@ spec:
           securityContext:
             privileged: true
             allowPrivilegeEscalation: true
-          image: openebs/lvm-driver1.2.0
+          image: openebs/lvm-driver:1.2.0
           imagePullPolicy: IfNotPresent
           args:
             - "--nodeid=$(OPENEBS_NODE_ID)"


### PR DESCRIPTION
#### Why is this change required?
It is need to avoid imagePullBackoff after installing the operator
#### What is changed?
A missing ":" is added back to the lvm-driver image name
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/openebs/charts/blob/HEAD/CONTRIBUTING.md#sign-your-commits) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
